### PR TITLE
Add contract keys to insurance policy contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ node_modules
 *.iml
 healthcare-backend/src/main/resources/frontend
 dist
+.daml/
+.classpath
+.project
+.settings/

--- a/README.md
+++ b/README.md
@@ -34,11 +34,14 @@ There are two options:
 
 #### Option 1: Start App with Docker
 
+Note: make sure to have at least 8gb of memory allocated to Docker.
+
 1. Type:
     ```shell
     docker-compose up --build
     ```
 2. Open UI with a browser at http://localhost:7500.
+
 
 #### Option 2: Start App in Standalone
 
@@ -275,9 +278,9 @@ To make payment:
    Details on this claim will be displayed.
 
 3. To pay the claim, choose the **Pay Claim** button.
-4. Enter the Policy contract id: #43:4
+4. Click the **Submit** button.
 
-   Payment will be sent to the Radiologist. The Radiologist can view their claims and see that this one is no longer an open claim by clicking on the **Claims** tab and enabling the **Include Archived** choice.
+   The payment will be sent to the Radiologist. The Radiologist can view their claims and see that this one is no longer an open claim by clicking on the **Claims** tab and enabling the **Include Archived** choice.
 
 5. Log in as Patient 1 and choose the **Patient Obligation** tab.
 

--- a/daml/DemoOnboardScenario/Claim.daml
+++ b/daml/DemoOnboardScenario/Claim.daml
@@ -20,7 +20,7 @@ payerPay : Party -> ContractId Claim -> ContractId InsurancePolicy -> Scenario (
 payerPay payer claim policy =
   payer `submit` do
     fetch claim
-    exercise claim PayClaim with policyCid = policy
+    exercise claim PayClaim
 
 patientAccept : Party -> TreatmentOutput -> Scenario (ContractId PatientObligation)
 patientAccept patient paymentReq =

--- a/daml/DemoOnboardScenario/ReferenceData.daml
+++ b/daml/DemoOnboardScenario/ReferenceData.daml
@@ -8,7 +8,7 @@ daml 1.2 module DemoOnboardScenario.ReferenceData where
 import Main.Types
 import DA.Next.Map
 import DA.Date
-
+import DA.Optional
 
 operator_party = getParty "ClearingHouse"
 
@@ -272,6 +272,7 @@ procedureCodeList = [X_Ray_Wrist_2_Views, X_Ray_Wrist_3_Views, Preventative_Care
 
 patientEncounter11 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient1"
     encounterId = "4afc77be"
     procedureCode = X_Ray_Wrist_3_Views
     diagnosisCode = Fracture_of_scaphoid_bone_right_wrist_S62_001
@@ -282,6 +283,7 @@ patientEncounter11 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter12 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient1"
     encounterId = "5afc77be"
     procedureCode = Preventative_Care
     diagnosisCode = Pain_in_right_arm_M79_601
@@ -292,6 +294,7 @@ patientEncounter12 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter13 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient1"
     encounterId = "5afc78be"
     procedureCode = Physicals
     diagnosisCode = Pain_in_right_arm_M79_601
@@ -302,6 +305,7 @@ patientEncounter13 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter14 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient1"
     encounterId = "4afc88be"
     procedureCode = X_Ray_Wrist_2_Views
     diagnosisCode = Open_fracture_of_scaphoid_bone_left_wrist_S62_002B
@@ -312,6 +316,7 @@ patientEncounter14 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter21 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient2"
     encounterId = "23ad8148"
     procedureCode = X_Ray_Wrist_2_Views
     diagnosisCode = Open_fracture_of_scaphoid_bone_left_wrist_S62_002B
@@ -322,6 +327,7 @@ patientEncounter21 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter22 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient2"
     encounterId = "33ad8148"
     procedureCode = Physicals
     diagnosisCode = Pain_in_left_arm_M79_602
@@ -332,6 +338,7 @@ patientEncounter22 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter23 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient2"
     encounterId = "23ad9148"
     procedureCode = X_Ray_Wrist_3_Views
     diagnosisCode = Fracture_of_scaphoid_bone_right_wrist_S62_001
@@ -342,6 +349,7 @@ patientEncounter23 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter31 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient3"
     encounterId = "23ad8149"
     procedureCode = X_Ray_Wrist_3_Views
     diagnosisCode = Fracture_of_scaphoid_bone_right_wrist_S62_001
@@ -352,6 +360,7 @@ patientEncounter31 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter32 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient3"
     encounterId = "43ad8149"
     procedureCode = Sick_Visits
     diagnosisCode = Pain_in_arm_unspecified_M79_603
@@ -362,6 +371,7 @@ patientEncounter32 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter33 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient3"
     encounterId = "23ad8249"
     procedureCode = X_Ray_Wrist_2_Views
     diagnosisCode = Open_fracture_of_scaphoid_bone_left_wrist_S62_002B
@@ -372,6 +382,7 @@ patientEncounter33 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter41 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient4"
     encounterId = "23ad8150"
     procedureCode = X_Ray_Wrist_2_Views
     diagnosisCode = Open_fracture_of_scaphoid_bone_left_wrist_S62_002B
@@ -382,6 +393,7 @@ patientEncounter41 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter42 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient4"
     encounterId = "53ad8150"
     procedureCode = Preventative_Care
     diagnosisCode = Pain_in_right_arm_M79_601
@@ -392,6 +404,7 @@ patientEncounter42 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter43 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient4"
     encounterId = "23ad8160"
     procedureCode = X_Ray_Wrist_3_Views
     diagnosisCode = Fracture_of_scaphoid_bone_right_wrist_S62_001
@@ -402,6 +415,7 @@ patientEncounter43 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter51 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient5"
     encounterId = "23ad8151"
     procedureCode = X_Ray_Wrist_3_Views
     diagnosisCode = Fracture_of_scaphoid_bone_right_wrist_S62_001
@@ -412,6 +426,7 @@ patientEncounter51 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter52 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient5"
     encounterId = "34ad8148"
     procedureCode = Physicals
     diagnosisCode = Pain_in_left_arm_M79_602
@@ -422,6 +437,7 @@ patientEncounter52 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter53 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient5"
     encounterId = "23ad9251"
     procedureCode = X_Ray_Wrist_2_Views
     diagnosisCode = Open_fracture_of_scaphoid_bone_left_wrist_S62_002B
@@ -432,6 +448,7 @@ patientEncounter53 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter61 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient6"
     encounterId = "23ad8152"
     procedureCode = X_Ray_Wrist_2_Views
     diagnosisCode = Open_fracture_of_scaphoid_bone_left_wrist_S62_002B
@@ -442,6 +459,7 @@ patientEncounter61 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter62 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient6"
     encounterId = "43ad8249"
     procedureCode = Sick_Visits
     diagnosisCode = Pain_in_arm_unspecified_M79_603
@@ -452,6 +470,7 @@ patientEncounter62 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter63 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient6"
     encounterId = "23ad9262"
     procedureCode = X_Ray_Wrist_3_Views
     diagnosisCode = Fracture_of_scaphoid_bone_right_wrist_S62_001
@@ -462,6 +481,7 @@ patientEncounter63 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter71 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient7"
     encounterId = "23ad9261"
     procedureCode = X_Ray_Wrist_2_Views
     diagnosisCode = Open_fracture_of_scaphoid_bone_left_wrist_S62_002B
@@ -472,6 +492,7 @@ patientEncounter71 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter72 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient7"
     encounterId = "44ad8249"
     procedureCode = Sick_Visits
     diagnosisCode = Pain_in_arm_unspecified_M79_603
@@ -482,6 +503,7 @@ patientEncounter72 = EncounterDetails
     appointmentPriority = "Elective"
 patientEncounter73 = EncounterDetails
   with
+    patient = fromSome $ partyFromText "Patient7"
     encounterId = "23ad9262"
     procedureCode = X_Ray_Wrist_3_Views
     diagnosisCode = Fracture_of_scaphoid_bone_right_wrist_S62_001

--- a/daml/Main/Claim.daml
+++ b/daml/Main/Claim.daml
@@ -22,8 +22,8 @@ template Claim
 
     controller payer can
       PayClaim : (ContractId PaymentReceipt, ContractId InsurancePolicy)
-        with policyCid : ContractId InsurancePolicy
         do
+        (policyCid, _) <- fetchByKey @InsurancePolicy (operator, payer, encounterDetails.patient)
         let
           procedureCode = encounterDetails.procedureCode
           maybePatientResp = encounterDetails.patientResponsibility

--- a/daml/Main/CostCalculation.daml
+++ b/daml/Main/CostCalculation.daml
@@ -29,6 +29,7 @@ calculateCosts ruleParams encounterStage =
           do
             procedure <- fetch procedureCid
             let updatedEncounter = EncounterDetails with
+                    patient = policy.patient
                     encounterId = encounterDetails.encounterId
                     diagnosisCode = encounterDetails.diagnosisCode
                     allowedAmount = None
@@ -47,6 +48,7 @@ calculateCosts ruleParams encounterStage =
             case maybeAmt of
               Some allowedAmount ->
                 let updatedEncounter = EncounterDetails with
+                        patient = policy.patient
                         encounterId = encounterDetails.encounterId
                         diagnosisCode = encounterDetails.diagnosisCode
                         allowedAmount = Some allowedAmount
@@ -58,6 +60,7 @@ calculateCosts ruleParams encounterStage =
                 return updatedEncounter
               None ->
                 let updatedEncounter = EncounterDetails with
+                        patient = policy.patient
                         encounterId = encounterDetails.encounterId
                         procedureCode
                         diagnosisCode = encounterDetails.diagnosisCode
@@ -70,6 +73,7 @@ calculateCosts ruleParams encounterStage =
                 return updatedEncounter
       None ->
         let updatedEncounter = EncounterDetails with
+                patient = policy.patient
                 encounterId = encounterDetails.encounterId
                 procedureCode
                 diagnosisCode = encounterDetails.diagnosisCode

--- a/daml/Main/Policy.daml
+++ b/daml/Main/Policy.daml
@@ -28,6 +28,9 @@ template InsurancePolicy
   where
     signatory payer
 
+    key (operator, payer, patient) : (Party, Party, Party)
+    maintainer key._2
+
     controller payer can
       LockProcedureOnAppointmentCreation : ContractId InsurancePolicy
         with

--- a/daml/Main/Provider.daml
+++ b/daml/Main/Provider.daml
@@ -58,8 +58,10 @@ template Provider
           siteServiceCode : Text
           appointmentPriority : Text
         do
-          disclosedPolicy <- do exercise policy Disclose with newReceiver = receiver
+          p <- fetch policy
+          disclosedPolicy <- exercise policy Disclose with newReceiver = receiver
           let encounterDetails = EncounterDetails with
+                patient = p.patient
                 allowedAmount = None
                 coPay = None
                 patientResponsibility = None; ..

--- a/daml/Main/Types.daml
+++ b/daml/Main/Types.daml
@@ -88,6 +88,7 @@ data DiagnosisCode = Fracture_of_scaphoid_bone_right_wrist_S62_001 |
 
 -- The encounter parameters of an appointment
 data EncounterDetails = EncounterDetails with
+  patient : Party
   encounterId : Text
   procedureCode : ProcedureCode
   diagnosisCode : DiagnosisCode

--- a/daml/Test/Claim.daml
+++ b/daml/Test/Claim.daml
@@ -28,7 +28,7 @@ claimTest = scenario do
 
     _claimReceipt <- payer1 `submit` do
       _c <- fetch claim
-      exercise claim PayClaim with policyCid = originalPolicy
+      exercise claim PayClaim
 
     patientObligation <- patient1 `submit`
       exercise paymentReq.patientReq AcceptPatientObligation

--- a/daml/Test/ReferenceData.daml
+++ b/daml/Test/ReferenceData.daml
@@ -8,6 +8,7 @@ daml 1.2 module Test.ReferenceData where
 import Main.Types
 import DA.Next.Map
 import DA.Date
+import DA.Optional
 
 -- InsuranceCompany
 payer1_payerHIN = "PAY1"
@@ -123,6 +124,7 @@ procedureCodeList = [X_Ray_Wrist_2_Views, X_Ray_Wrist_3_Views]
 
 patient1Encounter = EncounterDetails
   with
+    patient = fromSome $ partyFromText "John Doe"
     encounterId = "encounter1"
     procedureCode = X_Ray_Wrist_3_Views
     diagnosisCode = Fracture_of_scaphoid_bone_right_wrist_S62_001

--- a/src/test/java/com/digitalasset/refapps/healthcareclaims/HealthcareClaimsProcessingIT.java
+++ b/src/test/java/com/digitalasset/refapps/healthcareclaims/HealthcareClaimsProcessingIT.java
@@ -112,9 +112,7 @@ public class HealthcareClaimsProcessingIT {
     Claim.ContractId claim =
         ledgerAdapter.getCreatedContractId(
             INSURANCE_COMPANY_PARTY, Claim.TEMPLATE_ID, Claim.ContractId::new);
-    sandbox
-        .getLedgerAdapter()
-        .exerciseChoice(INSURANCE_COMPANY_PARTY, claim.exercisePayClaim());
+    sandbox.getLedgerAdapter().exerciseChoice(INSURANCE_COMPANY_PARTY, claim.exercisePayClaim());
 
     PatientObligation.ContractId obligation =
         ledgerAdapter.getCreatedContractId(

--- a/src/test/java/com/digitalasset/refapps/healthcareclaims/HealthcareClaimsProcessingIT.java
+++ b/src/test/java/com/digitalasset/refapps/healthcareclaims/HealthcareClaimsProcessingIT.java
@@ -112,12 +112,9 @@ public class HealthcareClaimsProcessingIT {
     Claim.ContractId claim =
         ledgerAdapter.getCreatedContractId(
             INSURANCE_COMPANY_PARTY, Claim.TEMPLATE_ID, Claim.ContractId::new);
-    InsurancePolicy.ContractId insurancePolicy =
-        ledgerAdapter.getCreatedContractId(
-            INSURANCE_COMPANY_PARTY, InsurancePolicy.TEMPLATE_ID, InsurancePolicy.ContractId::new);
     sandbox
         .getLedgerAdapter()
-        .exerciseChoice(INSURANCE_COMPANY_PARTY, claim.exercisePayClaim(insurancePolicy));
+        .exerciseChoice(INSURANCE_COMPANY_PARTY, claim.exercisePayClaim());
 
     PatientObligation.ContractId obligation =
         ledgerAdapter.getCreatedContractId(

--- a/src/test/java/com/digitalasset/refapps/healthcareclaims/bot/AcceptClaimBotTest.java
+++ b/src/test/java/com/digitalasset/refapps/healthcareclaims/bot/AcceptClaimBotTest.java
@@ -45,6 +45,7 @@ public class AcceptClaimBotTest {
             PrimaryCareProvider,
             InsuranceCompany,
             new EncounterDetails(
+                "Patient1",
                 "encounterId",
                 preventative_Care(),
                 pain_in_the_right_arn(),
@@ -63,6 +64,7 @@ public class AcceptClaimBotTest {
             PrimaryCareProvider,
             InsuranceCompany2,
             new EncounterDetails(
+                "Patient1",
                 "encounterId",
                 preventative_Care(),
                 pain_in_the_right_arn(),

--- a/src/test/java/com/digitalasset/refapps/healthcareclaims/bot/AcceptPatientPaymentRequestBotTest.java
+++ b/src/test/java/com/digitalasset/refapps/healthcareclaims/bot/AcceptPatientPaymentRequestBotTest.java
@@ -46,6 +46,7 @@ public class AcceptPatientPaymentRequestBotTest {
             PrimaryCareProvider,
             Patient1,
             new EncounterDetails(
+                Patient1,
                 "encounterId",
                 preventative_Care(),
                 pain_in_the_right_arn(),
@@ -65,6 +66,7 @@ public class AcceptPatientPaymentRequestBotTest {
             PrimaryCareProvider,
             Patient1,
             new EncounterDetails(
+                Patient1,
                 "encounterId",
                 preventative_Care(),
                 pain_in_the_right_arn(),

--- a/src/test/java/com/digitalasset/refapps/healthcareclaims/bot/EvaluateReferralBotTest.java
+++ b/src/test/java/com/digitalasset/refapps/healthcareclaims/bot/EvaluateReferralBotTest.java
@@ -76,6 +76,7 @@ public class EvaluateReferralBotTest {
         PrimaryCareProvider2,
         new DisclosedPolicy.ContractId("disclosedPolicyCid"),
         new EncounterDetails(
+            "Patient1",
             "encounterId",
             preventative_Care(),
             pain_in_the_right_arn(),

--- a/src/test/java/com/digitalasset/refapps/healthcareclaims/bot/UpdateReferralDetailsBotTest.java
+++ b/src/test/java/com/digitalasset/refapps/healthcareclaims/bot/UpdateReferralDetailsBotTest.java
@@ -66,6 +66,7 @@ public class UpdateReferralDetailsBotTest {
         PrimaryCareProvider,
         PrimaryCareProvider2,
         new EncounterDetails(
+            "Patient1",
             encounterId,
             preventative_Care(),
             pain_in_the_right_arn(),
@@ -89,6 +90,7 @@ public class UpdateReferralDetailsBotTest {
         new RuleParameters(
             new DisclosedPolicy.ContractId("policyCid"),
             new EncounterDetails(
+                "Patient1",
                 encounterId,
                 preventative_Care(),
                 pain_in_the_right_arn(),


### PR DESCRIPTION
Adds contract keys to the `InsurancePolicy` contract, so it doesn't have to be provided when paying a claim.