### PR TITLE
Change preventative to preventive to match healthcare terminology

### DIFF
--- a/model/daml/DemoOnboardScenario/ReferenceData.daml
+++ b/model/daml/DemoOnboardScenario/ReferenceData.daml
@@ -285,11 +285,11 @@ patient10Demographics = PatientDemographics
 feeSchedule : FeeSchedule
 feeSchedule = fromList [(X_Ray_Wrist_2_Views, 105.0),
                         (X_Ray_Wrist_3_Views, 125.0),
-                        (Preventative_Care, 60.0),
+                        (Preventive_Care, 60.0),
                         (Physicals, 55.0),
                         (Sick_Visits, 40.0)]
 
-procedureCodeList = [X_Ray_Wrist_2_Views, X_Ray_Wrist_3_Views, Preventative_Care, Physicals, Sick_Visits]
+procedureCodeList = [X_Ray_Wrist_2_Views, X_Ray_Wrist_3_Views, Preventive_Care, Physicals, Sick_Visits]
 
 patientEncounter11 = EncounterDetails
   with
@@ -306,7 +306,7 @@ patientEncounter12 = EncounterDetails
   with
     patient = fromSome $ partyFromText "Patient1"
     encounterId = "5afc77be"
-    procedureCode = Preventative_Care
+    procedureCode = Preventive_Care
     diagnosisCode = Pain_in_right_arm_M79_601
     allowedAmount = None
     coPay = None
@@ -416,7 +416,7 @@ patientEncounter42 = EncounterDetails
   with
     patient = fromSome $ partyFromText "Patient4"
     encounterId = "53ad8150"
-    procedureCode = Preventative_Care
+    procedureCode = Preventive_Care
     diagnosisCode = Pain_in_right_arm_M79_601
     allowedAmount = None
     coPay = None

--- a/model/daml/Main/Mapping.daml
+++ b/model/daml/Main/Mapping.daml
@@ -13,7 +13,7 @@ diagnosisToProcedureMapping : DiagnosisCode -> ProcedureCode -> Bool
 diagnosisToProcedureMapping diagnosisCode procedureCode
   =
   -- PCP visit
-  if procedureCode == Preventative_Care || procedureCode == Physicals ||
+  if procedureCode == Preventive_Care || procedureCode == Physicals ||
     procedureCode == Sick_Visits &&
     diagnosisCode == Pain_in_right_arm_M79_601 || diagnosisCode == Pain_in_left_arm_M79_602 || diagnosisCode == Pain_in_arm_unspecified_M79_603
     then True

--- a/model/daml/Main/Types.daml
+++ b/model/daml/Main/Types.daml
@@ -58,7 +58,7 @@ data PolicyType = Gold | Bronze deriving (Eq, Show)
 -- Mapping between procedure codes and fees
 type FeeSchedule = Map ProcedureCode Decimal
 
-data ProcedureCode = Preventative_Care | Physicals | Sick_Visits | X_Ray_Wrist_2_Views | X_Ray_Wrist_3_Views
+data ProcedureCode = Preventive_Care | Physicals | Sick_Visits | X_Ray_Wrist_2_Views | X_Ray_Wrist_3_Views
   deriving (Enum, Eq, Show, Ord)
 
 readEnum: Show a => Text -> [a] -> Text -> a

--- a/model/daml/Test/Procedure.daml
+++ b/model/daml/Test/Procedure.daml
@@ -37,7 +37,7 @@ testProcedureList = script
   do
     owner <- allocateParty "Owner"
     let
-      procedureList = [Preventative_Care , Physicals , Sick_Visits]
+      procedureList = [Preventive_Care , Physicals , Sick_Visits]
     newProcedureList <- owner `submit` do
       createProcedureList owner Bronze procedureList
     owner `submit` do
@@ -51,7 +51,7 @@ test2ProcedureList = script
     newObserver <- allocateParty "New One"
     let newObservers = [newObserver]
     let
-      procedureList = [Preventative_Care , Physicals , Sick_Visits]
+      procedureList = [Preventive_Care , Physicals , Sick_Visits]
     newProcedureList <- owner `submit` do
       createProcedureList owner Bronze procedureList
     display2 <- owner `submit` do

--- a/src/test/java/com/daml/product/healthcareclaims/HealthcareClaimsProcessingIT.java
+++ b/src/test/java/com/daml/product/healthcareclaims/HealthcareClaimsProcessingIT.java
@@ -99,7 +99,7 @@ public class HealthcareClaimsProcessingIT {
                 RADIOLOGIST_PARTY.getValue(),
                 policy,
                 "1",
-                ProcedureCode.PREVENTATIVE_CARE,
+                ProcedureCode.PREVENTIVE_CARE,
                 DiagnosisCode.PAIN_IN_RIGHT_ARM_M79_601,
                 "11",
                 "Elective"));
@@ -168,7 +168,7 @@ public class HealthcareClaimsProcessingIT {
                 RADIOLOGIST_PARTY.getValue(),
                 policy,
                 "1",
-                ProcedureCode.PREVENTATIVE_CARE,
+                ProcedureCode.PREVENTIVE_CARE,
                 DiagnosisCode.PAIN_IN_RIGHT_ARM_M79_601,
                 "11",
                 "Elective"));


### PR DESCRIPTION
Carol pointed out that we were using the wrong word here, this fixes it.